### PR TITLE
Handled unmarshalling when element exists but it is empty

### DIFF
--- a/lib/Doctrine/OXM/Marshaller/XmlMarshaller.php
+++ b/lib/Doctrine/OXM/Marshaller/XmlMarshaller.php
@@ -284,7 +284,9 @@ class XmlMarshaller implements Marshaller
                     } else {
                         // assume text element (dangerous?)
                         $cursor->read();
-                        if ($cursor->nodeType !== XMLReader::TEXT) {
+                        if (in_array($cursor->nodeType, array(XMLReader::WHITESPACE, XMLReader::SIGNIFICANT_WHITESPACE, XMLReader::END_ELEMENT))) {
+                            continue;
+                        } elseif ($cursor->nodeType !== XMLReader::TEXT) {
                             throw MarshallerException::invalidMarshallerState($cursor);
                         }
 

--- a/tests/Doctrine/Tests/OXM/Marshaller/MarshallerTest.php
+++ b/tests/Doctrine/Tests/OXM/Marshaller/MarshallerTest.php
@@ -129,7 +129,7 @@ class MarshallerTest extends \PHPUnit_Framework_TestCase
     {
         $simple = new Simple();
         $xml = $this->marshaller->marshalToString($simple);
-        
+
         $this->assertTrue(strlen($xml) > 0);
         $this->assertXmlStringEqualsXmlString('<?xml version="1.0" encoding="UTF-8"?><simple/>', $xml);
     }
@@ -251,5 +251,27 @@ class MarshallerTest extends \PHPUnit_Framework_TestCase
 
         $obj = $this->marshaller->unmarshalFromString($xml);
         $this->assertEquals('yes', $obj->other);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldSupportEmptyElement()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <address street="street">
+                <city></city>
+            </address>';
+
+        $address = $this->marshaller->unmarshalFromString($xml);
+        $this->assertEquals('', $address->getCity());
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <address street="street">
+                <city />
+            </address>';
+
+        $address = $this->marshaller->unmarshalFromString($xml);
+        $this->assertEquals('', $address->getCity());
     }
 }


### PR DESCRIPTION
`XMLReader::isEmptyElement()` does not consider elements like `<city />` or `<city></city>` to be empty. 

XmlMarshaller was failing when used in such scenarios because it was expecting text element (XMLReader::TEXT).

 In these cases, however, the element is an end element or a whitespace.
