### PR TITLE
[WIP] Add support for type parameters

### DIFF
--- a/lib/Doctrine/OXM/Types/ArrayType.php
+++ b/lib/Doctrine/OXM/Types/ArrayType.php
@@ -26,13 +26,13 @@ namespace Doctrine\OXM\Types;
  */
 class ArrayType extends Type
 {
-    public function convertToXmlValue($value, array $options = array())
+    public function convertToXmlValue($value, array $parameters = array())
     {
         return serialize($value);
     }
 
     // todo - use something more friendly here?  like implode/explode?
-    public function convertToPHPValue($value, array $options = array())
+    public function convertToPHPValue($value, array $parameters = array())
     {
         if ($value === null) {
             return null;

--- a/lib/Doctrine/OXM/Types/ArrayType.php
+++ b/lib/Doctrine/OXM/Types/ArrayType.php
@@ -26,13 +26,13 @@ namespace Doctrine\OXM\Types;
  */
 class ArrayType extends Type
 {
-    public function convertToXmlValue($value)
+    public function convertToXmlValue($value, array $options = array())
     {
         return serialize($value);
     }
 
     // todo - use something more friendly here?  like implode/explode?
-    public function convertToPHPValue($value)
+    public function convertToPHPValue($value, array $options = array())
     {
         if ($value === null) {
             return null;

--- a/lib/Doctrine/OXM/Types/BooleanType.php
+++ b/lib/Doctrine/OXM/Types/BooleanType.php
@@ -28,12 +28,12 @@ namespace Doctrine\OXM\Types;
  */
 class BooleanType extends Type
 {
-    public function convertToXmlValue($value)
+    public function convertToXmlValue($value, array $options = array())
     {
         return $value ? "true" : "false";
     }
-    
-    public function convertToPHPValue($value)
+
+    public function convertToPHPValue($value, array $options = array())
     {
         if ($value == "false") {
             return false;

--- a/lib/Doctrine/OXM/Types/BooleanType.php
+++ b/lib/Doctrine/OXM/Types/BooleanType.php
@@ -28,12 +28,12 @@ namespace Doctrine\OXM\Types;
  */
 class BooleanType extends Type
 {
-    public function convertToXmlValue($value, array $options = array())
+    public function convertToXmlValue($value, array $parameters = array())
     {
         return $value ? "true" : "false";
     }
 
-    public function convertToPHPValue($value, array $options = array())
+    public function convertToPHPValue($value, array $parameters = array())
     {
         if ($value == "false") {
             return false;

--- a/lib/Doctrine/OXM/Types/DateTimeType.php
+++ b/lib/Doctrine/OXM/Types/DateTimeType.php
@@ -26,28 +26,50 @@ namespace Doctrine\OXM\Types;
  */
 class DateTimeType extends Type
 {
-    const FORMAT = "Y-m-d G:i:s";
+    const DEFAULT_FORMAT = "Y-m-d G:i:s";
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return Type::DATETIME;
     }
 
-    public function convertToXmlValue($value)
+    /**
+     * @param \DateTime $value
+     * @param array     $options
+     * @return string
+     */
+    public function convertToXmlValue($value, array $options = array())
     {
-        return ($value !== null) ? $value->format(static::FORMAT) : null;
+        $format = array_key_exists('format', $options) ? $options['format'] : static::DEFAULT_FORMAT;
+
+        return !is_null($value) ? $value->format($format) : null;
     }
-    
-    public function convertToPHPValue($value)
+
+    /**
+     * @param string $value
+     * @param array  $options
+     * @return \DateTime
+     */
+    public function convertToPHPValue($value, array $options = array())
     {
-        if ($value === null) {
+        if (is_null($value)) {
             return null;
         }
 
-        $val = \DateTime::createFromFormat(static::FORMAT, $value);
-        if (!$val) {
+        try {
+            $format = array_key_exists('format', $options) ? $options['format'] : static::DEFAULT_FORMAT;
+            $val = \DateTime::createFromFormat($format, $value);
+
+            if ($val) {
+                return $val;
+            } else {
+                return new \DateTime($value);
+            }
+        } catch (\Exception $exception) {
             throw ConversionException::conversionFailed($value, $this->getName());
         }
-        return $val;
     }
 }

--- a/lib/Doctrine/OXM/Types/DateTimeType.php
+++ b/lib/Doctrine/OXM/Types/DateTimeType.php
@@ -38,29 +38,29 @@ class DateTimeType extends Type
 
     /**
      * @param \DateTime $value
-     * @param array     $options
+     * @param array     $parameters
      * @return string
      */
-    public function convertToXmlValue($value, array $options = array())
+    public function convertToXmlValue($value, array $parameters = array())
     {
-        $format = array_key_exists('format', $options) ? $options['format'] : static::DEFAULT_FORMAT;
+        $format = array_key_exists('format', $parameters) ? $parameters['format'] : static::DEFAULT_FORMAT;
 
         return !is_null($value) ? $value->format($format) : null;
     }
 
     /**
      * @param string $value
-     * @param array  $options
+     * @param array  $parameters
      * @return \DateTime
      */
-    public function convertToPHPValue($value, array $options = array())
+    public function convertToPHPValue($value, array $parameters = array())
     {
         if (is_null($value)) {
             return null;
         }
 
         try {
-            $format = array_key_exists('format', $options) ? $options['format'] : static::DEFAULT_FORMAT;
+            $format = array_key_exists('format', $parameters) ? $parameters['format'] : static::DEFAULT_FORMAT;
             $val = \DateTime::createFromFormat($format, $value);
 
             if ($val) {

--- a/lib/Doctrine/OXM/Types/DateTimeTzType.php
+++ b/lib/Doctrine/OXM/Types/DateTimeTzType.php
@@ -31,30 +31,15 @@ namespace Doctrine\OXM\Types;
  * @author      Jonathan Wage <jonwage@gmail.com>
  * @author      Roman Borschel <roman@code-factory.org>
  */
-class DateTimeTzType extends Type
+class DateTimeTzType extends DateTimeType
 {
-    const FORMAT = "Y-m-d G:i:sO";
+    const DEFAULT_FORMAT = "Y-m-d G:i:sO";
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return Type::DATETIMETZ;
-    }
-
-    public function convertToXmlValue($value)
-    {
-        return ($value !== null) ? $value->format(static::FORMAT) : null;
-    }
-
-    public function convertToPHPValue($value)
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        $val = \DateTime::createFromFormat(static::FORMAT, $value);
-        if (!$val) {
-            throw ConversionException::conversionFailed($value, $this->getName());
-        }
-        return $val;
     }
 }

--- a/lib/Doctrine/OXM/Types/DateType.php
+++ b/lib/Doctrine/OXM/Types/DateType.php
@@ -38,14 +38,14 @@ class DateType extends DateTimeType
 
     /**
      * @param string $value
-     * @param array  $options
+     * @param array  $parameters
      * @return \DateTime
      */
-    public function convertToPHPValue($value, array $options = array())
+    public function convertToPHPValue($value, array $parameters = array())
     {
-        $format = array_key_exists('format', $options) ? $options['format'] : static::DEFAULT_FORMAT;
-        $options['format'] = '!'.$format;
+        $format = array_key_exists('format', $parameters) ? $parameters['format'] : static::DEFAULT_FORMAT;
+        $parameters['format'] = '!'.$format;
 
-        return parent::convertToPHPValue($value, $options);
+        return parent::convertToPHPValue($value, $parameters);
     }
 }

--- a/lib/Doctrine/OXM/Types/DateType.php
+++ b/lib/Doctrine/OXM/Types/DateType.php
@@ -24,30 +24,28 @@ namespace Doctrine\OXM\Types;
  *
  * @since 2.0
  */
-class DateType extends Type
+class DateType extends DateTimeType
 {
-    const FORMAT = "Y-m-d";
+    const DEFAULT_FORMAT = "Y-m-d";
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return Type::DATE;
     }
-    public function convertToXmlValue($value)
-    {
-        return ($value !== null) 
-            ? $value->format(static::FORMAT) : null;
-    }
-    
-    public function convertToPHPValue($value)
-    {
-        if ($value === null) {
-            return null;
-        }
 
-        $val = \DateTime::createFromFormat('!'.static::FORMAT, $value);
-        if (!$val) {
-            throw ConversionException::conversionFailed($value, $this->getName());
-        }
-        return $val;
+    /**
+     * @param string $value
+     * @param array  $options
+     * @return \DateTime
+     */
+    public function convertToPHPValue($value, array $options = array())
+    {
+        $format = array_key_exists('format', $options) ? $options['format'] : static::DEFAULT_FORMAT;
+        $options['format'] = '!'.$format;
+
+        return parent::convertToPHPValue($value, $options);
     }
 }

--- a/lib/Doctrine/OXM/Types/FloatType.php
+++ b/lib/Doctrine/OXM/Types/FloatType.php
@@ -34,7 +34,7 @@ class FloatType extends Type
      * @param mixed $value The value to convert.
      * @return mixed The PHP representation of the value.
      */
-    public function convertToPHPValue($value, array $options = array())
+    public function convertToPHPValue($value, array $parameters = array())
     {
         return (null === $value) ? null : (float) $value;
     }

--- a/lib/Doctrine/OXM/Types/FloatType.php
+++ b/lib/Doctrine/OXM/Types/FloatType.php
@@ -34,7 +34,7 @@ class FloatType extends Type
      * @param mixed $value The value to convert.
      * @return mixed The PHP representation of the value.
      */
-    public function convertToPHPValue($value)
+    public function convertToPHPValue($value, array $options = array())
     {
         return (null === $value) ? null : (float) $value;
     }

--- a/lib/Doctrine/OXM/Types/IntegerType.php
+++ b/lib/Doctrine/OXM/Types/IntegerType.php
@@ -34,7 +34,7 @@ class IntegerType extends Type
         return Type::INTEGER;
     }
 
-    public function convertToPHPValue($value)
+    public function convertToPHPValue($value, array $options = array())
     {
         return (null === $value) ? null : (int) $value;
     }

--- a/lib/Doctrine/OXM/Types/IntegerType.php
+++ b/lib/Doctrine/OXM/Types/IntegerType.php
@@ -34,7 +34,7 @@ class IntegerType extends Type
         return Type::INTEGER;
     }
 
-    public function convertToPHPValue($value, array $options = array())
+    public function convertToPHPValue($value, array $parameters = array())
     {
         return (null === $value) ? null : (int) $value;
     }

--- a/lib/Doctrine/OXM/Types/ObjectType.php
+++ b/lib/Doctrine/OXM/Types/ObjectType.php
@@ -26,12 +26,12 @@ namespace Doctrine\OXM\Types;
  */
 class ObjectType extends Type
 {
-    public function convertToXmlValue($value)
+    public function convertToXmlValue($value, array $options = array())
     {
         return serialize($value);
     }
 
-    public function convertToPHPValue($value)
+    public function convertToPHPValue($value, array $options = array())
     {
         if ($value === null) {
             return null;

--- a/lib/Doctrine/OXM/Types/ObjectType.php
+++ b/lib/Doctrine/OXM/Types/ObjectType.php
@@ -26,12 +26,12 @@ namespace Doctrine\OXM\Types;
  */
 class ObjectType extends Type
 {
-    public function convertToXmlValue($value, array $options = array())
+    public function convertToXmlValue($value, array $parameters = array())
     {
         return serialize($value);
     }
 
-    public function convertToPHPValue($value, array $options = array())
+    public function convertToPHPValue($value, array $parameters = array())
     {
         if ($value === null) {
             return null;

--- a/lib/Doctrine/OXM/Types/TimeType.php
+++ b/lib/Doctrine/OXM/Types/TimeType.php
@@ -24,35 +24,15 @@ namespace Doctrine\OXM\Types;
  *
  * @since 2.0
  */
-class TimeType extends Type
+class TimeType extends DateTimeType
 {
-    const FORMAT = "G:i:s";
+    const DEFAULT_FORMAT = "G:i:s";
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return Type::TIME;
-    }
-    /**
-     * {@inheritdoc}
-     */
-    public function convertToXmlValue($value)
-    {
-        return ($value !== null) ? $value->format(static::FORMAT) : null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function convertToPHPValue($value)
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        $val = \DateTime::createFromFormat(static::FORMAT, $value);
-        if (!$val) {
-            throw ConversionException::conversionFailed($value, $this->getName());
-        }
-        return $val;
     }
 }

--- a/lib/Doctrine/OXM/Types/Type.php
+++ b/lib/Doctrine/OXM/Types/Type.php
@@ -71,10 +71,11 @@ abstract class Type
      * Converts a value from its PHP representation to its XML representation
      * of this type.
      *
-     * @param mixed $value The value to convert.
+     * @param mixed $value   The value to convert.
+     * @param array $options Type convertion options
      * @return mixed The XML representation of the value.
      */
-    public function convertToXmlValue($value)
+    public function convertToXmlValue($value, array $options = array())
     {
         return $value;
     }
@@ -83,10 +84,11 @@ abstract class Type
      * Converts a value from its database representation to its PHP representation
      * of this type.
      *
-     * @param mixed $value The value to convert.
+     * @param mixed $value   The value to convert.
+     * @param array $options Type convertion options
      * @return mixed The PHP representation of the value.
      */
-    public function convertToPHPValue($value)
+    public function convertToPHPValue($value, array $options = array())
     {
         return $value;
     }

--- a/lib/Doctrine/OXM/Types/Type.php
+++ b/lib/Doctrine/OXM/Types/Type.php
@@ -71,11 +71,11 @@ abstract class Type
      * Converts a value from its PHP representation to its XML representation
      * of this type.
      *
-     * @param mixed $value   The value to convert.
-     * @param array $options Type convertion options
+     * @param mixed $value      The value to convert.
+     * @param array $parameters Type convertion options
      * @return mixed The XML representation of the value.
      */
-    public function convertToXmlValue($value, array $options = array())
+    public function convertToXmlValue($value, array $parameters = array())
     {
         return $value;
     }
@@ -84,11 +84,11 @@ abstract class Type
      * Converts a value from its database representation to its PHP representation
      * of this type.
      *
-     * @param mixed $value   The value to convert.
-     * @param array $options Type convertion options
+     * @param mixed $value      The value to convert.
+     * @param array $parameters Type convertion options
      * @return mixed The PHP representation of the value.
      */
-    public function convertToPHPValue($value, array $options = array())
+    public function convertToPHPValue($value, array $parameters = array())
     {
         return $value;
     }

--- a/tests/Doctrine/Tests/OXM/Types/DateTimeTest.php
+++ b/tests/Doctrine/Tests/OXM/Types/DateTimeTest.php
@@ -26,10 +26,9 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     {
         $date = new \DateTime('1985-09-01 10:10:10');
 
-        $expected = '1985-09-01 10:10:10';
         $actual = $this->_type->convertToXmlValue($date);
 
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals('1985-09-01 10:10:10', $actual);
     }
 
     public function testDateTimeConvertsToPHPValue()
@@ -40,14 +39,46 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('1985-09-01 00:00:00', $date->format('Y-m-d H:i:s'));
     }
 
+    /**
+     * @expectedException \Doctrine\OXM\Types\ConversionException
+     */
     public function testInvalidDateTimeFormatConversion()
     {
-        $this->setExpectedException('Doctrine\OXM\Types\ConversionException');
         $this->_type->convertToPHPValue('abcdefg');
     }
 
     public function testNullConversion()
     {
         $this->assertNull($this->_type->convertToPHPValue(null));
+    }
+
+    public function testThatXmlValueFormatCanBeCustomised()
+    {
+        $date = new \DateTime('1985-09-01T10:10:10', new \DateTimeZone('America/New_York'));
+
+        $iso8601 = $this->_type->convertToXmlValue($date, array('format' => 'c'));
+        $custom = $this->_type->convertToXmlValue($date, array('format' => 'D, jS M Y'));
+
+        $this->assertEquals('1985-09-01T10:10:10-04:00', $iso8601);
+        $this->assertEquals('Sun, 1st Sep 1985', $custom);
+    }
+
+    public function testThatPhpValueFormatCanBeCustomised()
+    {
+        $iso8601 = $this->_type->convertToPhpValue('1985-09-01T10:10:10-04:00', array('format' => 'c'));
+        $custom = $this->_type->convertToPhpValue('Sun, 1st Sep 1985', array('format' => 'D, jS M Y'));
+
+        $this->assertInstanceOf('\DateTime', $iso8601);
+        $this->assertInstanceOf('\DateTime', $custom);
+        $this->assertEquals('1985-09-01T10:10:10-04:00', $iso8601->format('c'));
+        $this->assertEquals('Sun, 1st Sep 1985', $custom->format('D, jS M Y'));
+    }
+
+    /**
+     * @expectedException \Doctrine\OXM\Types\ConversionException
+     */
+    public function testUnsupportedFormat()
+    {
+        $this->_type->convertToPhpValue('1985-1981-01T10:10:10', array('format' => 'c'));
     }
 }


### PR DESCRIPTION
This is work in progress initially discussed in #18.

Done so far:
- Added support for type parameters (in Type classes)
- Refactored `DateTimeType` to accept format option 
- Extracted common date/time code to parent `DateTimeType` class
- All date/time types behave like before by default but accept format parameter which alters the bahvior

To be done:
- Add type parameters to the metadata
- Pass parameters to `convertToPHPValue()` and `convertToXmlValue()` methods in the `XmlMarshaller`
