### PR TITLE
Fixed possible infinite loop in XmlMarshaller while unmarshalling

### DIFF
--- a/lib/Doctrine/OXM/Marshaller/XmlMarshaller.php
+++ b/lib/Doctrine/OXM/Marshaller/XmlMarshaller.php
@@ -256,8 +256,7 @@ class XmlMarshaller implements Marshaller
         if (!$cursor->isEmptyElement) {
             $collectionElements = array();
 
-            while (true) {
-                $cursor->read();
+            while ($cursor->read()) {
                 if ($cursor->nodeType === XMLReader::END_ELEMENT && $cursor->name === $elementName) {
                     // we're at the original element closing node, bug out
                     break;


### PR DESCRIPTION
As additional reads from the cursor are done inside the loop it is possbile to fall into infinite loop. [XMLReader::read()](http://uk3.php.net/manual/en/xmlreader.read.php) method returns true on successful read. So instead of reading inside the loop it is better to do it in a condition.
