### PR TITLE
Allow xml text/cdata field to object property mapping

### DIFF
--- a/lib/Doctrine/OXM/Marshaller/Helper/WriterHelper.php
+++ b/lib/Doctrine/OXM/Marshaller/Helper/WriterHelper.php
@@ -95,13 +95,22 @@ class WriterHelper
         }
     }
 
+    public function writeText($value)
+    {
+        if ($this->needsCdataWrapping($value)) {
+            $this->cursor->writeCdata($value);
+        } else {
+            $this->cursor->text($value);
+        }
+    }
+
     public function writeNamespace($url, $prefix = null)
     {
         $attributeName = 'xmlns';
         if ($prefix) {
             $attributeName .= ":$prefix";
         }
-        
+
         $this->cursor->writeAttribute($attributeName, $url);
     }
 

--- a/lib/Doctrine/OXM/Marshaller/XmlMarshaller.php
+++ b/lib/Doctrine/OXM/Marshaller/XmlMarshaller.php
@@ -539,6 +539,8 @@ class XmlMarshaller implements Marshaller
             if ($classMetadata->hasFieldWrapping($fieldName)) {
                 $writer->endElement();
             }
+        } elseif ('#text' === $xmlName) {
+            $writer->writeText(Type::getType($type)->convertToXmlValue($fieldValue));
         } else {
             $writer->writeElement($xmlName, Type::getType($type)->convertToXmlValue($fieldValue), $prefix);
         }

--- a/lib/Doctrine/OXM/Marshaller/XmlMarshaller.php
+++ b/lib/Doctrine/OXM/Marshaller/XmlMarshaller.php
@@ -268,7 +268,7 @@ class XmlMarshaller implements Marshaller
                     break;
                 }
 
-                if ($cursor->nodeType !== XMLReader::ELEMENT && $cursor->nodeType !== XMLReader::CDATA) {
+                if ($cursor->nodeType !== XMLReader::ELEMENT && $cursor->nodeType !== XMLReader::CDATA && $cursor->nodeType !== XMLReader::TEXT) {
                     // skip insignificant elements
                     continue;
                 }
@@ -288,7 +288,9 @@ class XmlMarshaller implements Marshaller
                         }
                     } else {
                         // assume text element (dangerous?)
-                        $cursor->read();
+                        if ($cursor->nodeType !== XMLReader::TEXT && $cursor->nodeType !== XMLReader::CDATA) {
+                            $cursor->read();
+                        }
 
                         if (!$cursor->isEmptyElement && $cursor->nodeType !== XMLReader::END_ELEMENT) {
                             if ($cursor->nodeType !== XMLReader::TEXT && $cursor->nodeType !== XMLReader::CDATA) {

--- a/tests/Doctrine/Tests/OXM/Entities/Role.php
+++ b/tests/Doctrine/Tests/OXM/Entities/Role.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Tests\OXM\Entities;
+
+/**
+ * @XmlEntity
+ */
+class Role
+{
+    /**
+     * @var boolean
+     *
+     * @XmlAttribute(type="boolean")
+     */
+    public $isActive;
+
+    /**
+     * @var string
+     *
+     * @XmlText(type="string", name="#text")
+     */
+    public $name;
+}

--- a/tests/Doctrine/Tests/OXM/Marshaller/MarshallerTest.php
+++ b/tests/Doctrine/Tests/OXM/Marshaller/MarshallerTest.php
@@ -36,7 +36,8 @@ use \Doctrine\OXM\Mapping\ClassMetadataFactory,
     \Doctrine\Tests\OXM\Entities\Tag,
     \Doctrine\Tests\OXM\Entities\Bar,
     \Doctrine\Tests\OXM\Entities\CustomerContact,
-    \Doctrine\Tests\OXM\Entities\Address;
+    \Doctrine\Tests\OXM\Entities\Address,
+    \Doctrine\Tests\OXM\Entities\Role;
 
 /**
  * @ErrorHandlerSettings false
@@ -304,6 +305,20 @@ class MarshallerTest extends \PHPUnit_Framework_TestCase
 
         $obj2 = $this->marshaller->unmarshalFromString($xml);
         $this->assertEquals('', $obj2->baz);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldSupportElementsWithBothAttributesAndText()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <role is-active="true">Manager</role>';
+
+        $role = $this->marshaller->unmarshalFromString($xml);
+
+        $this->assertTrue($role->isActive);
+        $this->assertEquals('Manager', $role->name);
     }
 
     /**

--- a/tests/Doctrine/Tests/OXM/Marshaller/MarshallerTest.php
+++ b/tests/Doctrine/Tests/OXM/Marshaller/MarshallerTest.php
@@ -341,6 +341,37 @@ class MarshallerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function itShouldUnmarshalCdataElementsWithAttributes()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?><role is-active="true"><![CDATA[Man&ager]]></role>';
+
+        $role = $this->marshaller->unmarshalFromString($xml);
+
+        $this->assertTrue($role->isActive);
+        $this->assertEquals('Man&ager', $role->name);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldMarshalCdataElementsWithAttributes()
+    {
+        $role = new Role();
+        $role->isActive = true;
+        $role->name = 'Man&ager';
+
+        $xml = $this->marshaller->marshalToString($role);
+
+        $expectedXml = '<?xml version="1.0" encoding="UTF-8"?>
+<role is-active="true"><![CDATA[Man&ager]]></role>
+';
+
+        $this->assertEquals($expectedXml, $xml);
+    }
+
+    /**
+     * @test
+     */
     public function itShouldHandleCircularReferences()
     {
         $article = new Article();

--- a/tests/Doctrine/Tests/OXM/Marshaller/MarshallerTest.php
+++ b/tests/Doctrine/Tests/OXM/Marshaller/MarshallerTest.php
@@ -310,15 +310,32 @@ class MarshallerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function itShouldSupportElementsWithBothAttributesAndText()
+    public function itShouldUnmarshalTextElementsWithAttributes()
     {
-        $xml = '<?xml version="1.0" encoding="UTF-8"?>
-            <role is-active="true">Manager</role>';
+        $xml = '<?xml version="1.0" encoding="UTF-8"?><role is-active="true">Manager</role>';
 
         $role = $this->marshaller->unmarshalFromString($xml);
 
         $this->assertTrue($role->isActive);
         $this->assertEquals('Manager', $role->name);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldMarshalTextElementsWithAttributes()
+    {
+        $role = new Role();
+        $role->isActive = true;
+        $role->name = 'Manager';
+
+        $xml = $this->marshaller->marshalToString($role);
+
+        $expectedXml = '<?xml version="1.0" encoding="UTF-8"?>
+<role is-active="true">Manager</role>
+';
+
+        $this->assertEquals($expectedXml, $xml);
     }
 
     /**


### PR DESCRIPTION
It is currently not possible to marshal XML like:

```
<role is-active="true">Manager</role>
```

Into an object:

```
Role
{
    public $isActive;

    public $name;
}
```

Attached commits make it possible by using '#text' as a name.

```
/**
 * @OXM\XmlEntity
 */
class Role
{
    /**
     * @OXM\XmlAttribute(type="boolean", name="isActive")
     */
    private $isActive = null;

    /**
     * @OXM\XmlText(type="string", name="#text")
     */
    private $name = null;
}
```

Let me know if I took the wrong approach and I'll update my PR. 

It doesn't handle CDATA properly yet but sooner I get feedback the better.
